### PR TITLE
Update README.md to specify the active parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The implementation of the MoE layer in this repository is not efficient. The imp
 
 Grok-1 is currently designed with the following specifications:
 
-- **Parameters:** 314B
+- **Parameters:** 314B (86B active)
 - **Architecture:** Mixture of 8 Experts (MoE)
 - **Experts Utilization:** 2 experts used per token
 - **Layers:** 64


### PR DESCRIPTION
This is important because users may think they need to have the full 314B at one time, but only 86B which is much more manageable!