### PR TITLE
replaced cuda12_pip with cuda12-pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dm_haiku==0.0.12
-jax[cuda12_pip]==0.4.25 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+jax[cuda12-pip]==0.4.25 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 numpy==1.26.4
 sentencepiece==0.2.0


### PR DESCRIPTION
The `cuda12-pip` package was wrongly named `cuda12_pip` so I fix in the name has been applied.